### PR TITLE
[JBEE-220] Skip maven deploy plugin for EE4J modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
         <findbugs.version>3.0.5</findbugs.version>
         <findbugs.exclude>exclude.xml</findbugs.exclude>
         <findbugs.threshold>Low</findbugs.threshold>
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
     <modules>


### PR DESCRIPTION
Skipping the implicit maven deploy plugin on parent EE4J project to allow only deployments of the jboss api module

Jira issue: https://issues.jboss.org/browse/JBEE-220